### PR TITLE
bugfix: do not apply brightness filter on tooltips

### DIFF
--- a/include/stylesheet.css
+++ b/include/stylesheet.css
@@ -229,14 +229,14 @@ body {
 }
 
 .circle {
-    position: relative;
+    /* position: relative; */
     width: 14px;
     height: 14px;
     border-radius: 25px;
     background-color: var(--secondary_color);
     /* margin: 2px; */
     margin-right: 2px;
-    float: left;
+    /* float: left; */
     border: 1px var(--tertiary_color) outset;
     filter: brightness(0.67);
 }
@@ -251,7 +251,8 @@ img.circle {
     transition: 250ms;
 }
 
-.circle:first-child {
+/* .circle:first-child { */
+#default_tab {
     margin-left: 5px;
 }
 
@@ -262,7 +263,7 @@ img.circle {
 }
 
 /* tab switcher tooltips */
-.circle:hover .tab_tooltip {
+.circle:hover + .tab_tooltip {
     position:absolute;
     top:-35px;
     left: -8px;
@@ -272,6 +273,11 @@ img.circle {
     border: 1px solid var(--tertiary_color);
     background-color: var(--secondary_color);
     color:var(--text_color);
+}
+
+.tab_wrapper{
+    position:relative;
+    float:left;
 }
 
 .tab_tooltip{

--- a/index.html
+++ b/index.html
@@ -17,16 +17,20 @@
     <div class="background" id="main_display">
         <div id="header">
             <div id="tab_switcher">
-                <div id="default_tab" class="circle circle_active" onclick="change_active_tab({'num':1, 'elem':this})">
+                <div class="tab_wrapper">
+                    <div id="default_tab" class="circle circle_active" onclick="change_active_tab({'num':1, 'elem':this})"></div>
                     <div class="tab_tooltip"><strong>Links</strong></div>
                 </div>
-                <div class="circle" onclick="change_active_tab({'num':2, 'elem':this})">
+                <div class="tab_wrapper">
+                    <div class="circle" onclick="change_active_tab({'num':2, 'elem':this})"></div>
                     <div class="tab_tooltip"><strong>Discord</strong></div>
                 </div>
-                <div class="circle" onclick="change_active_tab({'num':3, 'elem':this})">
+                <div class="tab_wrapper">
+                    <div class="circle" onclick="change_active_tab({'num':3, 'elem':this})"></div>
                     <div class="tab_tooltip"><strong>Calendar</strong></div>
                 </div>
-                <div class="circle" onclick="change_active_tab({'num':4, 'elem':this})">
+                <div class="tab_wrapper">
+                    <div class="circle" onclick="change_active_tab({'num':4, 'elem':this})"></div>
                     <div class="tab_tooltip"><strong>Spotify</strong></div>
                 </div>
                 <img src="include/imgs/small_settings_light.png" class="circle" onclick="change_active_tab({'num':999, 'elem':this})">


### PR DESCRIPTION
Hi Chase,
actually this behaviour doesn't look like a bug to me.
I mean, when the tab is not active the corrisponding tooltip is "grayed"(less bright),
when you activate a tab the tooltip becomes brighter,
so the tooltip brightness indicates if the tab is active or activable.
It came automatically, cause the brightness filter is inherited and tab div is the parent of tooltip div.

But, if you prefer to have all the tooltips the same brightness,
I've already prepared a fix. It was not so easy, I really spent some time.

"divs" containing the tooltip has been moved outside the div implementing the circle tab
